### PR TITLE
Add support for S3-compatible backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Native macOS menu bar app heavily inspired by Apple's Time Machine to perform sc
 
 * Built-in restic binary (but using a custom one is also possible)
 * Back up every hour, day or week
-* SFTP, rest or local repository types
+* SFTP, rest, S3 (+ compatible) or local repository types
 * List of included/excluded files/folders
 * Custom command-line arguments
 

--- a/ResticRunner/ResticRunnerService.swift
+++ b/ResticRunner/ResticRunnerService.swift
@@ -99,6 +99,7 @@ class ResticRunnerService: ResticRunnerProtocol {
     process.qualityOfService = .background
     process.executableURL = restic.executableURL
     var environment = ProcessInfo.processInfo.environment
+    environment.merge(restic.environment, uniquingKeysWith: { _, new in new })
     environment["RESTIC_REPOSITORY"] = restic.repository
     environment["RESTIC_PASSWORD"] = restic.password
     environment["RESTIC_PROGRESS_FPS"] = "0.2"

--- a/ResticRunner/ResticRunnerService.swift
+++ b/ResticRunner/ResticRunnerService.swift
@@ -99,10 +99,11 @@ class ResticRunnerService: ResticRunnerProtocol {
     process.qualityOfService = .background
     process.executableURL = restic.executableURL
     var environment = ProcessInfo.processInfo.environment
-    environment.merge(restic.environment, uniquingKeysWith: { _, new in new })
     environment["RESTIC_REPOSITORY"] = restic.repository
     environment["RESTIC_PASSWORD"] = restic.password
     environment["RESTIC_PROGRESS_FPS"] = "0.2"
+    environment["AWS_ACCESS_KEY_ID"] = restic.s3AccessKeyId
+    environment["AWS_SECRET_ACCESS_KEY"] = restic.s3SecretAccessKey
     process.environment = environment
     do {
       try FileManager.default.createDirectory(at: restic.logURL.deletingLastPathComponent(), withIntermediateDirectories: true)

--- a/ResticScheduler/AppEnvironment.swift
+++ b/ResticScheduler/AppEnvironment.swift
@@ -33,8 +33,14 @@ class AppEnvironment {
     }
   }
 
+  var resticEnvironment: [String: String] {
+    ["AWS_ACCESS_KEY_ID": s3AccessKeyId, "AWS_SECRET_ACCESS_KEY": s3SecretAccessKey]
+  }
+
   @UserDefault("BackupFrequency") var backupFrequency = 86400
   @UserDefault("ResticRepository") var resticRepository = FileManager.default.temporaryDirectory.path(percentEncoded: false)
+  @UserDefault("ResticS3AccessKeyId") var s3AccessKeyId = ""
+  @KeychainPassword("ResticS3SecretAccessKey") var s3SecretAccessKey
   @KeychainPassword("ResticPassword") var resticPassword
   @UserDefault("ResticBinary") var resticBinary: String?
   @UserDefault("ResticHost") var resticHost: String?

--- a/ResticScheduler/AppEnvironment.swift
+++ b/ResticScheduler/AppEnvironment.swift
@@ -35,7 +35,7 @@ class AppEnvironment {
 
   @UserDefault("BackupFrequency") var backupFrequency = 86400
   @UserDefault("ResticRepository") var resticRepository = FileManager.default.temporaryDirectory.path(percentEncoded: false)
-  @UserDefault("ResticS3AccessKeyId") var s3AccessKeyId = ""
+  @UserDefault("ResticS3AccessKeyId") var s3AccessKeyId: String?
   @KeychainPassword("ResticS3SecretAccessKey") var s3SecretAccessKey
   @KeychainPassword("ResticPassword") var resticPassword
   @UserDefault("ResticBinary") var resticBinary: String?

--- a/ResticScheduler/AppEnvironment.swift
+++ b/ResticScheduler/AppEnvironment.swift
@@ -33,10 +33,6 @@ class AppEnvironment {
     }
   }
 
-  var resticEnvironment: [String: String] {
-    ["AWS_ACCESS_KEY_ID": s3AccessKeyId, "AWS_SECRET_ACCESS_KEY": s3SecretAccessKey]
-  }
-
   @UserDefault("BackupFrequency") var backupFrequency = 86400
   @UserDefault("ResticRepository") var resticRepository = FileManager.default.temporaryDirectory.path(percentEncoded: false)
   @UserDefault("ResticS3AccessKeyId") var s3AccessKeyId = ""

--- a/ResticScheduler/ResticRunnerService.swift
+++ b/ResticScheduler/ResticRunnerService.swift
@@ -42,6 +42,7 @@ extension Restic {
       password: AppEnvironment.shared.resticPassword,
       host: AppEnvironment.shared.resticHost,
       binary: AppEnvironment.shared.resticBinary,
+      environment: AppEnvironment.shared.resticEnvironment,
       arguments: AppEnvironment.shared.resticArguments,
       includes: AppEnvironment.shared.resticIncludes,
       excludes: AppEnvironment.shared.resticExcludes,

--- a/ResticScheduler/ResticRunnerService.swift
+++ b/ResticScheduler/ResticRunnerService.swift
@@ -39,10 +39,11 @@ extension Restic {
   static func environment() -> Restic {
     Restic(
       repository: AppEnvironment.shared.resticRepository,
+      s3AccessKeyId: AppEnvironment.shared.s3AccessKeyId,
+      s3SecretAccessKey: AppEnvironment.shared.s3SecretAccessKey,
       password: AppEnvironment.shared.resticPassword,
       host: AppEnvironment.shared.resticHost,
       binary: AppEnvironment.shared.resticBinary,
-      environment: AppEnvironment.shared.resticEnvironment,
       arguments: AppEnvironment.shared.resticArguments,
       includes: AppEnvironment.shared.resticIncludes,
       excludes: AppEnvironment.shared.resticExcludes,

--- a/ResticScheduler/ResticSettings.swift
+++ b/ResticScheduler/ResticSettings.swift
@@ -69,7 +69,7 @@ class ResticSettings: Model {
       guard !ignoringChanges else { return }
       guard s3AccessKeyId != oldValue else { return }
 
-      AppEnvironment.shared.s3AccessKeyId = s3AccessKeyId
+      AppEnvironment.shared.s3AccessKeyId = s3AccessKeyId == "" ? nil : s3AccessKeyId
       ResticScheduler.shared.rescheduleStaleBackupCheck()
     }
   }
@@ -140,7 +140,7 @@ class ResticSettings: Model {
       default:
         repository = resticRepository
       }
-      s3AccessKeyId = AppEnvironment.shared.s3AccessKeyId
+      s3AccessKeyId = AppEnvironment.shared.s3AccessKeyId ?? ""
       s3SecretAccessKey = AppEnvironment.shared.s3SecretAccessKey
       password = AppEnvironment.shared.resticPassword
       includes = AppEnvironment.shared.resticIncludes

--- a/ResticScheduler/ResticSettingsView.swift
+++ b/ResticScheduler/ResticSettingsView.swift
@@ -23,6 +23,8 @@ struct ResticSettingsView: View {
             .tag(ResticSettings.RepositoryType.sftp)
           Text("Rest")
             .tag(ResticSettings.RepositoryType.rest)
+          Text("S3")
+            .tag(ResticSettings.RepositoryType.s3)
           Text("Browse…")
             .tag(ResticSettings.RepositoryType.browse)
         }
@@ -30,9 +32,13 @@ struct ResticSettingsView: View {
           resticSettings.repositoryType = .local
           resticSettings.repository = try! result.get().path(percentEncoded: false)
         })
-        if [ResticSettings.RepositoryType.sftp, ResticSettings.RepositoryType.rest].contains(resticSettings.repositoryType) {
+        if resticSettings.repositoryType.hasAddress {
           TextField("Address:", text: $resticSettings.repository)
             .padding(.bottom, 10)
+        }
+        if resticSettings.repositoryType == .s3 {
+            TextField("Access Key ID:", text: $resticSettings.s3AccessKeyId)
+            SecureField("Secret Access Key:", text: $resticSettings.s3SecretAccessKey)
         }
         SecureField("Password:", text: $resticSettings.password)
         LabeledContent("Included files:") {

--- a/ResticScheduler/ResticSettingsView.swift
+++ b/ResticScheduler/ResticSettingsView.swift
@@ -34,11 +34,11 @@ struct ResticSettingsView: View {
         })
         if resticSettings.repositoryType.hasAddress {
           TextField("Address:", text: $resticSettings.repository)
-            .padding(.bottom, 10)
-        }
-        if resticSettings.repositoryType == .s3 {
-            TextField("Access Key ID:", text: $resticSettings.s3AccessKeyId)
-            SecureField("Secret Access Key:", text: $resticSettings.s3SecretAccessKey)
+          if resticSettings.repositoryType == .s3 {
+              TextField("Access Key ID:", text: $resticSettings.s3AccessKeyId)
+              SecureField("Secret Access Key:", text: $resticSettings.s3SecretAccessKey)
+          }
+          Spacer(minLength: 18)
         }
         SecureField("Password:", text: $resticSettings.password)
         LabeledContent("Included files:") {

--- a/ResticSchedulerKit/ResticRunner.swift
+++ b/ResticSchedulerKit/ResticRunner.swift
@@ -5,17 +5,19 @@ import Foundation
   public let password: String
   public let binary: String?
   public let host: String?
+  public let environment: [String: String]
   public let arguments: [String]
   public let includes: [String]
   public let excludes: [String]
   public let logURL: URL
   public let summaryURL: URL
 
-  public init(repository: String, password: String, host: String?, binary: String?, arguments: [String], includes: [String], excludes: [String], logURL: URL, summaryURL: URL) {
+  public init(repository: String, password: String, host: String?, binary: String?, environment: [String: String], arguments: [String], includes: [String], excludes: [String], logURL: URL, summaryURL: URL) {
     self.repository = repository
     self.password = password
     self.host = host
     self.binary = binary
+    self.environment = environment
     self.arguments = arguments
     self.includes = includes
     self.excludes = excludes
@@ -30,6 +32,7 @@ import Foundation
     coder.encode(password, forKey: "password")
     coder.encode(binary, forKey: "binary")
     coder.encode(host, forKey: "host")
+    coder.encode(environment, forKey: "environment")
     coder.encode(arguments, forKey: "arguments")
     coder.encode(includes, forKey: "includes")
     coder.encode(excludes, forKey: "excludes")
@@ -42,6 +45,7 @@ import Foundation
     password = coder.decodeObject(of: NSString.self, forKey: "password")! as String
     binary = coder.decodeObject(of: NSString.self, forKey: "binary") as String?
     host = coder.decodeObject(of: NSString.self, forKey: "host") as String?
+    environment = coder.decodeDictionary(withKeyClass: NSString.self, objectClass: NSString.self, forKey: "environment")! as [String: String]
     arguments = coder.decodeArrayOfObjects(ofClass: NSString.self, forKey: "arguments")! as [String]
     includes = coder.decodeArrayOfObjects(ofClass: NSString.self, forKey: "includes")! as [String]
     excludes = coder.decodeArrayOfObjects(ofClass: NSString.self, forKey: "excludes")! as [String]

--- a/ResticSchedulerKit/ResticRunner.swift
+++ b/ResticSchedulerKit/ResticRunner.swift
@@ -2,22 +2,24 @@ import Foundation
 
 @objc public class Restic: NSObject, NSSecureCoding {
   public let repository: String
+  public let s3AccessKeyId: String?
+  public let s3SecretAccessKey: String?
   public let password: String
   public let binary: String?
   public let host: String?
-  public let environment: [String: String]
   public let arguments: [String]
   public let includes: [String]
   public let excludes: [String]
   public let logURL: URL
   public let summaryURL: URL
 
-  public init(repository: String, password: String, host: String?, binary: String?, environment: [String: String], arguments: [String], includes: [String], excludes: [String], logURL: URL, summaryURL: URL) {
+  public init(repository: String, s3AccessKeyId: String?, s3SecretAccessKey: String?, password: String, host: String?, binary: String?, arguments: [String], includes: [String], excludes: [String], logURL: URL, summaryURL: URL) {
     self.repository = repository
+    self.s3AccessKeyId = s3AccessKeyId
+    self.s3SecretAccessKey = s3SecretAccessKey
     self.password = password
     self.host = host
     self.binary = binary
-    self.environment = environment
     self.arguments = arguments
     self.includes = includes
     self.excludes = excludes
@@ -29,10 +31,11 @@ import Foundation
 
   public func encode(with coder: NSCoder) {
     coder.encode(repository, forKey: "repository")
+    coder.encode(s3AccessKeyId, forKey: "s3AccessKeyId")
+    coder.encode(s3SecretAccessKey, forKey: "s3SecretAccessKey")
     coder.encode(password, forKey: "password")
     coder.encode(binary, forKey: "binary")
     coder.encode(host, forKey: "host")
-    coder.encode(environment, forKey: "environment")
     coder.encode(arguments, forKey: "arguments")
     coder.encode(includes, forKey: "includes")
     coder.encode(excludes, forKey: "excludes")
@@ -42,10 +45,11 @@ import Foundation
 
   public required init?(coder: NSCoder) {
     repository = coder.decodeObject(of: NSString.self, forKey: "repository")! as String
+    s3AccessKeyId = coder.decodeObject(of: NSString.self, forKey: "s3AccessKeyId") as String?
+    s3SecretAccessKey = coder.decodeObject(of: NSString.self, forKey: "s3SecretAccessKey") as String?
     password = coder.decodeObject(of: NSString.self, forKey: "password")! as String
     binary = coder.decodeObject(of: NSString.self, forKey: "binary") as String?
     host = coder.decodeObject(of: NSString.self, forKey: "host") as String?
-    environment = coder.decodeDictionary(withKeyClass: NSString.self, objectClass: NSString.self, forKey: "environment")! as [String: String]
     arguments = coder.decodeArrayOfObjects(ofClass: NSString.self, forKey: "arguments")! as [String]
     includes = coder.decodeArrayOfObjects(ofClass: NSString.self, forKey: "includes")! as [String]
     excludes = coder.decodeArrayOfObjects(ofClass: NSString.self, forKey: "excludes")! as [String]


### PR DESCRIPTION
This PR adds support for backing up to AWS S3 buckets, and to other object storage services with an S3-compatible API such as Backblaze. In addition to an address similar to the one for SFTP and REST servers, S3 needs a key ID and a key. This PR adds fields for these, right below the address field, that only show up when S3 is selected:

<img width="624" src="https://github.com/user-attachments/assets/78d9dd37-3947-4bab-9a92-6eb0a74cf1a1" />

The values of these fields are then passed to Restic in the corresponding environment variables. The key ID is stored in UserDefaults, while the key is stored in the Keychain.

Restic docs:
- [Preparing a new repository: Amazon S3](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#amazon-s3)
- [Preparing a new respository: S3-compatible storage](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#s3-compatible-storage)