### PR TITLE
Enable reordering in lists

### DIFF
--- a/ResticScheduler/EditableListView.swift
+++ b/ResticScheduler/EditableListView.swift
@@ -14,7 +14,7 @@ struct EditableListView: View {
 
   var body: some View {
     ScrollViewReader { proxy in
-      List($editableList.list, selection: $editableList.selection) { item in
+      List($editableList.list, editActions: .move, selection: $editableList.selection) { item in
         TextField("", text: item.value)
           .font(.callout)
           .listRowInsets(.init())


### PR DESCRIPTION
Enables drag and drop reordering within lists, for more convenient editing of lists in cases where the ordering matters, such as when passing arguments that take their own parameters, or just to order included or excluded files in a logical way.

I originally made this change for the argument list because the ordering really matters there, but I then kept it for all lists because giving users the option to reorder the list of included and excluded files doesn't hurt either and might be convenient for folks who want to keep the lists in an order that makes sense to them.

https://github.com/user-attachments/assets/d25c8b8c-89f8-466d-aca0-664006010cc9
