### PR TITLE
Fix content type for custom restic binary

### DIFF
--- a/ResticScheduler/AdvancedSettingsView.swift
+++ b/ResticScheduler/AdvancedSettingsView.swift
@@ -26,7 +26,7 @@ struct AdvancedSettingsView: View {
               .tag(AdvancedSettings.BinaryType.browse)
           }
           .padding(.bottom, advancedSettings.binaryVersion.value == "" ? 10 : 0)
-          .fileImporter(isPresented: $advancedSettings.browseBinary, allowedContentTypes: [.content], onCompletion: { result in
+          .fileImporter(isPresented: $advancedSettings.browseBinary, allowedContentTypes: [.unixExecutable], onCompletion: { result in
             advancedSettings.binary = try! result.get().path(percentEncoded: false)
             advancedSettings.binaryType = .manual
           })


### PR DESCRIPTION
Executables have the `public.unix-executable` content type. With `public.content`, binaries and symlinks to binaries aren't selectable (at least not on macOS Sequoia, I can't test on older systems).

I've tested this with the actual restic binary and a symlink to it.

|`.content`|`.unixExecutable`|
|-|-|
|<img width="989" src="https://github.com/user-attachments/assets/c0e05ad5-176f-4e70-99dc-d6f67843ea66" />|<img width="989" src="https://github.com/user-attachments/assets/da5688f9-bc42-4f9c-b1ea-b6a94a017597" />|


